### PR TITLE
Update CLI and add server data directory paths in run script

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-code-tunnel/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-code-tunnel/run
@@ -5,5 +5,6 @@ exec \
         s6-setuidgid abc \
             /usr/bin/code tunnel \
                 --accept-server-license-terms \
-                --cli-data-dir /config/data \
+                --cli-data-dir /config/data/cli \
+                --server-data-dir /config/data/server \
                 --name "${TUNNEL_NAME}"


### PR DESCRIPTION
This pull request makes a minor update to the code tunnel service configuration by specifying a separate directory for server data.

- Service configuration update:
  * In `root/etc/s6-overlay/s6-rc.d/svc-code-tunnel/run`, the `code tunnel` command now uses `--cli-data-dir /config/data/cli` and adds `--server-data-dir /config/data/server` to separate CLI and server data storage locations.

These changes will be available in the next monthly build.